### PR TITLE
NCL-1920: Add wild card on sophos adapter query

### DIFF
--- a/src/libcharon/plugins/windows_dns/windows_dns_handler.c
+++ b/src/libcharon/plugins/windows_dns/windows_dns_handler.c
@@ -212,7 +212,7 @@ static int GetTapAdapterInfo( IWbemServices *pSvc, int *iface_idx, wchar_t *dns1
 	{
 		// Allocate our strings
 		language = SysAllocString( L"WQL" );
-		query = SysAllocString( L"SELECT * FROM Win32_NetworkAdapterConfiguration where Description LIKE 'Sophos TAP Adapter'" );
+		query = SysAllocString( L"SELECT * FROM Win32_NetworkAdapterConfiguration where Description LIKE 'Sophos TAP Adapter%'" );
 
 		// Get the current DNS servers list for our adapter
 		hres = pSvc->lpVtbl->ExecQuery( pSvc, language, query, WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY, NULL, &pEnumerator );


### PR DESCRIPTION
Issue : In some systems where the Sophos connect tap adapter has a count suffixed to it name. Then the adapter query from strongswan would fail because of the count added at the end.

Fix: make the query more robust (wild card) so that it can query the adapter even if then name has a count suffixed 