### PR TITLE
libtls: Enforce client/server identity when looking for public key

### DIFF
--- a/src/libtls/tls_peer.c
+++ b/src/libtls/tls_peer.c
@@ -165,7 +165,7 @@ struct private_tls_peer_t {
 
 /* Implemented in tls_server.c */
 bool tls_write_key_share(bio_writer_t **key_share, diffie_hellman_t *dh);
-public_key_t *tls_find_public_key(auth_cfg_t *peer_auth);
+public_key_t *tls_find_public_key(auth_cfg_t *peer_auth, identification_t *id);
 
 /**
  * Verify the DH group/key type requested by the server is valid.
@@ -641,7 +641,7 @@ static status_t process_cert_verify(private_tls_peer_t *this,
 	public_key_t *public;
 	chunk_t msg;
 
-	public = tls_find_public_key(this->server_auth);
+	public = tls_find_public_key(this->server_auth, this->server);
 	if (!public)
 	{
 		DBG1(DBG_TLS, "no trusted certificate found for '%Y' to verify TLS server",
@@ -690,7 +690,7 @@ static status_t process_modp_key_exchange(private_tls_peer_t *this,
 		this->alert->add(this->alert, TLS_FATAL, TLS_INTERNAL_ERROR);
 		return NEED_MORE;
 	}
-	public = tls_find_public_key(this->server_auth);
+	public = tls_find_public_key(this->server_auth, this->server);
 	if (!public)
 	{
 		DBG1(DBG_TLS, "no TLS public key found for server '%Y'", this->server);
@@ -797,7 +797,7 @@ static status_t process_ec_key_exchange(private_tls_peer_t *this,
 		return NEED_MORE;
 	}
 
-	public = tls_find_public_key(this->server_auth);
+	public = tls_find_public_key(this->server_auth, this->server);
 	if (!public)
 	{
 		DBG1(DBG_TLS, "no TLS public key found for server '%Y'", this->server);
@@ -1621,7 +1621,7 @@ static status_t send_key_exchange_encrypt(private_tls_peer_t *this,
 		return NEED_MORE;
 	}
 
-	public = tls_find_public_key(this->server_auth);
+	public = tls_find_public_key(this->server_auth, this->server);
 	if (!public)
 	{
 		DBG1(DBG_TLS, "no TLS public key found for server '%Y'", this->server);

--- a/src/libtls/tls_server.c
+++ b/src/libtls/tls_server.c
@@ -173,7 +173,7 @@ struct private_tls_server_t {
 /**
  * Find a trusted public key to encrypt/verify key exchange data
  */
-public_key_t *tls_find_public_key(auth_cfg_t *peer_auth)
+public_key_t *tls_find_public_key(auth_cfg_t *peer_auth, identification_t *id)
 {
 	public_key_t *public = NULL, *current;
 	certificate_t *cert, *found;
@@ -184,8 +184,7 @@ public_key_t *tls_find_public_key(auth_cfg_t *peer_auth)
 	if (cert)
 	{
 		enumerator = lib->credmgr->create_public_enumerator(lib->credmgr,
-											KEY_ANY, cert->get_subject(cert),
-											peer_auth, TRUE);
+												KEY_ANY, id, peer_auth, TRUE);
 		while (enumerator->enumerate(enumerator, &current, &auth))
 		{
 			found = auth->get(auth, AUTH_RULE_SUBJECT_CERT);
@@ -923,7 +922,7 @@ static status_t process_cert_verify(private_tls_server_t *this,
 	public_key_t *public;
 	chunk_t msg;
 
-	public = tls_find_public_key(this->peer_auth);
+	public = tls_find_public_key(this->peer_auth, this->peer);
 	if (!public)
 	{
 		DBG1(DBG_TLS, "no trusted certificate found for '%Y' to verify TLS peer",


### PR DESCRIPTION
> cherry-pick https://github.com/strongswan/strongswan/commit/e4b4aabc4996fc61c37deab7858d07bc4d220136 to `5.9.5`
