### PR TITLE
NCL-1920 Failed to establish conn with Tap adapter from StongSwan Sophos connect agent (windows)

### DIFF
--- a/src/libcharon/plugins/windows_dns/windows_dns_handler.c
+++ b/src/libcharon/plugins/windows_dns/windows_dns_handler.c
@@ -212,7 +212,7 @@ static int GetTapAdapterInfo( IWbemServices *pSvc, int *iface_idx, wchar_t *dns1
 	{
 		// Allocate our strings
 		language = SysAllocString( L"WQL" );
-		query = SysAllocString( L"SELECT * FROM Win32_NetworkAdapterConfiguration where Description LIKE 'Sophos TAP Adapter'" );
+		query = SysAllocString( L"SELECT * FROM Win32_NetworkAdapterConfiguration where Description LIKE 'Sophos TAP Adapter%'" );
 
 		// Get the current DNS servers list for our adapter
 		hres = pSvc->lpVtbl->ExecQuery( pSvc, language, query, WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY, NULL, &pEnumerator );

--- a/src/libcharon/plugins/windows_dns/windows_dns_handler.c
+++ b/src/libcharon/plugins/windows_dns/windows_dns_handler.c
@@ -222,7 +222,7 @@ static int GetTapAdapterInfo( IWbemServices *pSvc, int *iface_idx, wchar_t *dns1
 			break;
 		}
 
-		// This call fetches the first matching network adapter configuration object, if available.	   
+		// This call picks the first matching network adapter configuration object   
 		hres = pEnumerator->lpVtbl->Next( pEnumerator, WBEM_INFINITE, 1, &pClassObj, &uReturn );
 		if ( 0 == uReturn )
 		{

--- a/src/libcharon/plugins/windows_dns/windows_dns_handler.c
+++ b/src/libcharon/plugins/windows_dns/windows_dns_handler.c
@@ -222,7 +222,7 @@ static int GetTapAdapterInfo( IWbemServices *pSvc, int *iface_idx, wchar_t *dns1
 			break;
 		}
 
-		// We assume only 1 matching result
+		// This call fetches the first matching network adapter configuration object, if available.	   
 		hres = pEnumerator->lpVtbl->Next( pEnumerator, WBEM_INFINITE, 1, &pClassObj, &uReturn );
 		if ( 0 == uReturn )
 		{


### PR DESCRIPTION
**_Jira:_**
NCL-1920 Failed to establish conn with Tap adapter from StongSwan Sophos connect agent (windows)

_**Root Cause Analysis (RCA):**_
When the Sophos TAP Adapter is installed on a Windows system, the friendly name assigned to the adapter can sometimes include an automatically appended suffix — for example, "Sophos TAP Adapter #2" — if a previous instance already exists or due to Windows naming behavior.

In WMI (Win32_NetworkAdapterConfiguration), the Description field for the adapter typically mirrors this **friendly name**, including any such suffix. However, if the code attempts to retrieve the adapter using an exact string match (e.g., "Description LIKE 'Sophos TAP Adapter'"), the query will fail because no adapter exactly matches that string.

As a result, even though the TAP adapter is present on the system, the WMI query does not return any results, causing the code to miss detecting the adapter and behave as though it is not installed.

_**Fix:**_
To address this issue, the WMI query was updated to use a LIKE clause with a wildcard:

This ensures that the query matches any adapter whose description starts with "Sophos TAP Adapter", regardless of any appended suffix or numbering.
